### PR TITLE
jobコントローラのバグ修正

### DIFF
--- a/data/10.txt
+++ b/data/10.txt
@@ -200,7 +200,7 @@ URLでうけとった token をもとに求人をさがし、みつかったら 
         else {
             $self->form->fill({
                 $job->get_columns,
-                category => $job->category->name,
+                category => $job->category->slug,
             });
         }
     }


### PR DESCRIPTION
`name`だと`Design`とか`Programming`とかになってeditを開いたときにDBに入れた内容を反映できませんでした。
`slug`で`design`とかにすればeditを開いたときにちゃんと値を反映しました。
