### PR TITLE
jobコントローラのバグ修正

### DIFF
--- a/10.md
+++ b/10.md
@@ -204,7 +204,7 @@ URLでうけとった token をもとに求人をさがし、みつかったら 
         else {
             $self->form->fill({
                 $job->get_columns,
-                category => $job->category->name,
+                category => $job->category->slug,
             });
         }
     }


### PR DESCRIPTION
`name`だと`Design`とか`Programming`とかになってeditを開いたときにDBに入れた内容を反映できませんでした。
`slug`で`design`とかにすればeditを開いたときにちゃんと値を反映しました。
