### PR TITLE
タイポ修正

### DIFF
--- a/03.md
+++ b/03.md
@@ -560,7 +560,7 @@ Affiliate クラス:
             size        => 255,
             is_nullable => 0,
             @_,
-        },
+        };
     }
 
     sub DATETIME {


### PR DESCRIPTION
`03.md` の `line: 563` ですが、

```
    sub VARCHAR {
        +{
            data_type   => 'VARCHAR',
            size        => 255,
            is_nullable => 0,
            @_,
        },
    }
```

となっていました。`;` が正しいのかなと思い、PRしました。